### PR TITLE
Reformat code to be more idiomatic

### DIFF
--- a/ch04/lfsr/exploit_lfsr/exploit_lfsr_test.go
+++ b/ch04/lfsr/exploit_lfsr/exploit_lfsr_test.go
@@ -112,16 +112,17 @@ func TestKnownPlaintextAttack(t *testing.T) {
 
 	remainingCiphertext := ciphertext[len(AttackMessageKnownPrefix):]
 	for i := 1; i < MaxLfsrLength; i++ {
-		if clonedLfsr, err := RecoverLFSRWithKnownLengthFromObservedBits(keystreamBits, i); err == nil {
-			decrypted := clonedLfsr.Encrypt(remainingCiphertext)
-			if parsedTs, err := time.Parse(time.RFC822, string(decrypted)); err != nil {
-				t.Logf("Incorrect decrypted message: %s", decrypted)
-				continue
-			} else {
-				t.Logf("Decrypted message: %s%s\n", AttackMessageKnownPrefix, parsedTs)
-				return
-			}
+		clonedLfsr, err := RecoverLFSRWithKnownLengthFromObservedBits(keystreamBits, i)
+		if err != nil {
+			continue
 		}
+		decrypted := clonedLfsr.Encrypt(remainingCiphertext)
+		if parsedTs, err := time.Parse(time.RFC822, string(decrypted)); err == nil {
+			t.Logf("Decrypted message: %s%s\n", AttackMessageKnownPrefix, parsedTs)
+			return
+		}
+
+		t.Logf("Incorrect decrypted message: %s", decrypted)
 	}
 
 	t.Fatalf("Could not decrypt message")

--- a/ch05/beast/exploit_beast/exploit_beast_test.go
+++ b/ch05/beast/exploit_beast/exploit_beast_test.go
@@ -15,17 +15,15 @@ func TestEncryptedHTTPSession(t *testing.T) {
 
 	t.Logf("recoveredSessionId: %s\n", recoveredSessionId)
 
-	if impl_beast.ValidateSessionId(host, recoveredSessionId) {
-		t.Logf("recoveredSessionId verified successfully against host %s", host)
-	} else {
+	if !impl_beast.ValidateSessionId(host, recoveredSessionId) {
 		t.Fatalf("recoveredSessionId is incorrect, does not match the one stored for host %s", host)
 	}
+	t.Logf("recoveredSessionId verified successfully against host %s", host)
 
 	differentHost := "someotherhost.com"
 	_, _, _ = impl_beast.NewEncryptedHTTPSession(differentHost, "/")
-	if !impl_beast.ValidateSessionId(differentHost, recoveredSessionId) {
-		t.Logf("recoveredSessionId is correctly invalid for a different host")
-	} else {
+	if impl_beast.ValidateSessionId(differentHost, recoveredSessionId) {
 		t.Fatalf("recoveredSessionId is incorrectly valid for a different host")
 	}
+	t.Logf("recoveredSessionId is correctly invalid for a different host")
 }

--- a/ch06/length_ext/impl_length_ext/impl_length_ext.go
+++ b/ch06/length_ext/impl_length_ext/impl_length_ext.go
@@ -78,10 +78,8 @@ func (b *Bank) authenticateRequest(r *http.Request) (uint32, error) {
 	}
 	clientId32 := uint32(clientId)
 
-	var clientSecret string
-	if v, ok := b.clientSecrets[clientId32]; ok {
-		clientSecret = v
-	} else {
+	clientSecret, ok := b.clientSecrets[clientId32]
+	if !ok {
 		return 0, errors.New("client not found")
 	}
 
@@ -106,12 +104,12 @@ func (b *Bank) authenticateRequest(r *http.Request) (uint32, error) {
 			reqTime,
 			currentTime,
 			currentTime-reqTime))
-	} else {
-		fmt.Printf("\trequest authenticated successfully, requestTime: %d, currentTime: %d, delta: %d (µs)\n",
-			reqTime,
-			currentTime,
-			currentTime-reqTime)
 	}
+
+	fmt.Printf("\trequest authenticated successfully, requestTime: %d, currentTime: %d, delta: %d (µs)\n",
+		reqTime,
+		currentTime,
+		currentTime-reqTime)
 
 	return clientId32, nil
 }
@@ -169,7 +167,6 @@ func (b *Bank) NewClient(
 	}
 	clientId = newClientResponse["clientId"]
 	clientSecret = newClientResponse["clientSecret"]
-	return
 }
 
 func (b *Bank) CheckBalanceHttpHandler(w http.ResponseWriter, r *http.Request) {

--- a/ch08/rsa_bleichenbacher_sig/exploit_rsa_bleichenbacher_sig/exploit_rsa_bleichenbacher_sig.go
+++ b/ch08/rsa_bleichenbacher_sig/exploit_rsa_bleichenbacher_sig/exploit_rsa_bleichenbacher_sig.go
@@ -88,10 +88,9 @@ func ForgeSignatureForPublicExponent3(pubKey *rsa.PublicKey, hashAlg crypto.Hash
 
 		sigNum := new(big.Int).SetBytes(sig)
 		sigCleartext := new(big.Int).Exp(sigNum, big.NewInt(3), nil).Bytes()
-		if bytes.IndexByte(sigCleartext[:len(sigCleartext)-len(suffix)], byte(0x00)) != -1 {
-			fmt.Printf("sigCleartext has a zero byte, retrying\n")
-		} else {
+		if bytes.IndexByte(sigCleartext[:len(sigCleartext)-len(suffix)], byte(0x00)) == -1 {
 			return sig, nil
 		}
+		fmt.Printf("sigCleartext has a zero byte, retrying\n")
 	}
 }


### PR DESCRIPTION
The primary changes are removing unnecessary nesting and else clauses.